### PR TITLE
feat: #7 add conversion rules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "Python: Current File",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${file}",
       "console": "integratedTerminal",
@@ -14,11 +14,11 @@
     },
     {
       "name": "main (Workspace must be sourced before execution)",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "autoware_msg_bag_converter/main.py",
       "console": "integratedTerminal",
-      "args": ["$HOME/data/sample-rosbag", "$HOME/data/converted-rosbag"]
+      "args": ["$HOME/convert_test/input_bag", "$HOME/convert_test/converted_bag"]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,9 @@
     "${env:HOME}/ros_ws/converter/install/autoware_auto_perception_msgs/local/lib/python3.10/dist-packages",
     "${env:HOME}/ros_ws/converter/install/autoware_auto_planning_msgs/local/lib/python3.10/dist-packages",
     "${env:HOME}/ros_ws/converter/install/autoware_auto_system_msgs/local/lib/python3.10/dist-packages",
-    "${env:HOME}/ros_ws/converter/install/autoware_auto_vehicle_msgs/local/lib/python3.10/dist-packages"
+    "${env:HOME}/ros_ws/converter/install/autoware_auto_vehicle_msgs/local/lib/python3.10/dist-packages",
+
+    "${env:HOME}/ros_ws/converter/install/tier4_planning_msgs/local/lib/python3.10/dist-packages"
   ],
   "python.analysis.extraPaths": [
     "/opt/ros/humble/lib/python3.10/site-packages",
@@ -62,7 +64,9 @@
     "${env:HOME}/ros_ws/converter/install/autoware_auto_perception_msgs/local/lib/python3.10/dist-packages",
     "${env:HOME}/ros_ws/converter/install/autoware_auto_planning_msgs/local/lib/python3.10/dist-packages",
     "${env:HOME}/ros_ws/converter/install/autoware_auto_system_msgs/local/lib/python3.10/dist-packages",
-    "${env:HOME}/ros_ws/converter/install/autoware_auto_vehicle_msgs/local/lib/python3.10/dist-packages"
+    "${env:HOME}/ros_ws/converter/install/autoware_auto_vehicle_msgs/local/lib/python3.10/dist-packages",
+
+    "${env:HOME}/ros_ws/converter/install/tier4_planning_msgs/local/lib/python3.10/dist-packages"
   ],
   "ros.distro": "humble"
 }

--- a/README.md
+++ b/README.md
@@ -37,10 +37,22 @@ source install/setup.bash
 cd src/autoware_msg_bag_converter/autoware_msg_bag_converter
 
 # convert one bag
-python3 main.py ${input_bag} ${output_bag}
+python3 main.py ${input_bag_dir} ${output_bag_dir}
 
 # convert multi bags in directory
-python3 main.py ${input_bag_dir} ${output_bag_dir} -d
+python3 main.py ${input_bag_dir_root} ${output_bag_dir_root} -d
+```
+
+```shell
+# example
+$ tree
+bag_root # <- input_bag_dir_root
+├── sample_mcap # <- input_bag_dir 
+│   ├── metadata.yaml
+│   └── sample_mcap_0.db3
+└── sample_sqlite3 # <- input_bag_dir 
+    ├── metadata.yaml
+    └── sample_sqlite3_0.db3
 ```
 
 ## demo

--- a/autoware_msg_bag_converter/converter.py
+++ b/autoware_msg_bag_converter/converter.py
@@ -53,16 +53,16 @@ TYPES_TO_ADD_AUTOWARE_PREFIX = [
 
 
 def change_topic_type(old_type: TopicMetadata) -> TopicMetadata:
-    if old_type.name in TYPES_NOT_SIMPLY_REPLACED:
+    if old_type.type in TYPES_NOT_SIMPLY_REPLACED:
         return TopicMetadata(
             name=old_type.name,
-            type=TYPES_NOT_SIMPLY_REPLACED[old_type.name],
+            type=TYPES_NOT_SIMPLY_REPLACED[old_type.type],
             serialization_format="cdr",
         )
-    if any(old_type.name.startswith(prefix) for prefix in TYPES_TO_ADD_AUTOWARE_PREFIX):
+    if any(old_type.type.startswith(prefix) for prefix in TYPES_TO_ADD_AUTOWARE_PREFIX):
         return TopicMetadata(
             name=old_type.name,
-            type=f"autoware_{old_type.name}",
+            type=f"autoware_{old_type.type}",
             serialization_format="cdr",
         )
     # If old_type is not in the conversion rules, simply remove "auto_" and use that as the new type.

--- a/autoware_msg_bag_converter/converter.py
+++ b/autoware_msg_bag_converter/converter.py
@@ -18,21 +18,55 @@
 
 from pathlib import Path
 
+from autoware_auto_control_msgs.msg import AckermannControlCommand
+from autoware_control_msgs.msg import Control
+from rclpy.serialization import deserialize_message
+from rclpy.serialization import serialize_message
 from rosbag2_py import Reindexer
 from rosbag2_py import TopicMetadata
+from rosidl_runtime_py.utilities import get_message
 
 from autoware_msg_bag_converter.bag import create_reader
 from autoware_msg_bag_converter.bag import create_writer
 from autoware_msg_bag_converter.bag import get_storage_options
 
+TYPES_NOT_SIMPLY_REPLACED = {
+    "autoware_auto_control_msgs/msg/AckermannControlCommand": "autoware_control_msgs/msg/Control",
+}
+
 
 def change_topic_type(old_type: TopicMetadata) -> TopicMetadata:
-    # If old_type is not of type autoware_auto, the original message type remains
+    if old_type.name in TYPES_NOT_SIMPLY_REPLACED:
+        return TopicMetadata(
+            name=old_type.name,
+            type=TYPES_NOT_SIMPLY_REPLACED[old_type.name],
+            serialization_format="cdr",
+        )
+    # If old_type is not in the conversion rules, simply remove "auto_" and use that as the new type.
     return TopicMetadata(
         name=old_type.name,
         type=old_type.type.replace("autoware_auto_", "autoware_"),
         serialization_format="cdr",
     )
+
+
+def convert_msg(topic_name: str, msg: bytes, type_map: dict) -> bytes:
+    # get old msg type
+    old_type = type_map[topic_name]
+    if old_type not in TYPES_NOT_SIMPLY_REPLACED:
+        return msg
+    old_msg = deserialize_message(
+        msg,
+        get_message(type_map[topic_name]),
+    )
+    if old_type == "autoware_auto_control_msgs/msg/AckermannControlCommand":
+        old_msg: AckermannControlCommand
+        return Control(
+            stamp=old_msg.stamp,
+            lateral=old_msg.lateral,
+            longitudinal=old_msg.longitudinal,
+        )
+    return None
 
 
 def convert_bag(input_bag_path: str, output_bag_path: str) -> None:
@@ -47,7 +81,7 @@ def convert_bag(input_bag_path: str, output_bag_path: str) -> None:
     writer = create_writer(output_bag_path, storage_type)
 
     # create topic
-    type_map = {}
+    type_map = {}  # key: topic_name value: old_type's msg type
     for topic_type in reader.get_all_topics_and_types():
         type_map[topic_type.name] = topic_type.type
         new_topic_type = change_topic_type(
@@ -58,7 +92,8 @@ def convert_bag(input_bag_path: str, output_bag_path: str) -> None:
     # copy data from input bag to output bag
     while reader.has_next():
         topic_name, msg, stamp = reader.read_next()
-        writer.write(topic_name, msg, stamp)
+        new_msg = convert_msg(topic_name, msg, type_map)
+        writer.write(topic_name, new_msg, stamp)
 
     # reindex to update metadata.yaml
     del writer

--- a/autoware_msg_bag_converter/converter.py
+++ b/autoware_msg_bag_converter/converter.py
@@ -17,22 +17,34 @@
 # https://github.com/ros2/rosbag2/blob/rolling/rosbag2_py/test/test_reindexer.py
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from autoware_auto_control_msgs.msg import AckermannControlCommand
 from autoware_control_msgs.msg import Control
 from rclpy.serialization import deserialize_message
 from rclpy.serialization import serialize_message
 from rosbag2_py import Reindexer
 from rosbag2_py import TopicMetadata
 from rosidl_runtime_py.utilities import get_message
+from tier4_planning_msgs.msg import PathWithLaneId as T4PathWithLaneId
 
 from autoware_msg_bag_converter.bag import create_reader
 from autoware_msg_bag_converter.bag import create_writer
 from autoware_msg_bag_converter.bag import get_storage_options
 
+if TYPE_CHECKING:
+    from autoware_auto_control_msgs.msg import AckermannControlCommand
+    from autoware_auto_planning_msgs.msg import PathWithLaneId as AutoPathWithLaneId
+
 TYPES_NOT_SIMPLY_REPLACED = {
     "autoware_auto_control_msgs/msg/AckermannControlCommand": "autoware_control_msgs/msg/Control",
+    "autoware_auto_planning_msgs/msg/PathWithLaneId": "tier4_planning_msgs/msg/PathWithLaneId",
 }
+
+TYPES_TO_ADD_AUTOWARE_PREFIX = [
+    "control_validator/msg/ControlValidatorStatus",
+    "planning_validator/msg/PlanningValidatorStatus",
+    "vehicle_cmd_gate/msg/IsFilterActivated",
+]
 
 
 def change_topic_type(old_type: TopicMetadata) -> TopicMetadata:
@@ -40,6 +52,12 @@ def change_topic_type(old_type: TopicMetadata) -> TopicMetadata:
         return TopicMetadata(
             name=old_type.name,
             type=TYPES_NOT_SIMPLY_REPLACED[old_type.name],
+            serialization_format="cdr",
+        )
+    if old_type.name in TYPES_TO_ADD_AUTOWARE_PREFIX:
+        return TopicMetadata(
+            name=old_type.name,
+            type=f"autoware_{old_type.name}",
             serialization_format="cdr",
         )
     # If old_type is not in the conversion rules, simply remove "auto_" and use that as the new type.
@@ -61,10 +79,22 @@ def convert_msg(topic_name: str, msg: bytes, type_map: dict) -> bytes:
     )
     if old_type == "autoware_auto_control_msgs/msg/AckermannControlCommand":
         old_msg: AckermannControlCommand
-        return Control(
-            stamp=old_msg.stamp,
-            lateral=old_msg.lateral,
-            longitudinal=old_msg.longitudinal,
+        return serialize_message(
+            Control(
+                stamp=old_msg.stamp,
+                lateral=old_msg.lateral,
+                longitudinal=old_msg.longitudinal,
+            ),
+        )
+    if old_type == "autoware_auto_planning_msgs/msg/PathWithLaneId":
+        old_msg: AutoPathWithLaneId
+        return serialize_message(
+            T4PathWithLaneId(
+                header=old_msg.header,
+                points=old_msg.points,
+                left_bound=old_msg.left_bound,
+                right_bound=old_msg.right_bound,
+            ),
         )
     return None
 

--- a/dependency.repos
+++ b/dependency.repos
@@ -12,3 +12,7 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
+  autoware/tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/tier4_autoware_msgs.git
+    version: tier4/universe

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -21,15 +21,25 @@ from autoware_msg_bag_converter.converter import change_topic_type
 
 
 def test_change_topic_type() -> None:
-    old_type = TopicMetadata(
+    auto_type = TopicMetadata(
         name="/vehicle/status/control_mode",
         type="autoware_auto_vehicle_msgs/msg/ControlModeReport",
         serialization_format="cdr",
     )
-    new_type = change_topic_type(old_type)
+    new_type = change_topic_type(auto_type)
     assert new_type.name == "/vehicle/status/control_mode"
     assert new_type.type == "autoware_vehicle_msgs/msg/ControlModeReport"
     assert new_type.serialization_format == "cdr"
+
+    not_auto_type = TopicMetadata(
+        name="/tf",
+        type="tf2_msgs/msg/TFMessage",
+        serialization_format="cdr",
+    )
+    not_changed_type = change_topic_type(not_auto_type)
+    assert not_auto_type.name == not_changed_type.name
+    assert not_auto_type.type == not_changed_type.type
+    assert not_auto_type.serialization_format == not_changed_type.serialization_format
 
 
 def test_get_rosbag_path() -> None:


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- Support for message types whose structure changed in the process of changing from autoware_auto_msg to autoware_msg
- add conversion rule
- Added ability to add autoware prefix to type name
- https://github.com/autowarefoundation/autoware_msg_bag_converter/pull/1/files#diff-deeb8d084bed507ff1f246e7c2fe3cea17e928af6311f888d7a58e4c5b355147R48-R52

## How to review this PR

Convert bag(s) acquired by vehicle when autoware_auto_msg.

```
# convert one bag
python3 main.py ${input_bag} ${output_bag}

# convert multi bags in directory
python3 main.py ${input_bag_dir} ${output_bag_dir} -d
```

## Others

https://github.com/hayato-m126/autoware_msg_bag_converter/issues/7
